### PR TITLE
Update talents.md

### DIFF
--- a/content/balance/guide/talents.md
+++ b/content/balance/guide/talents.md
@@ -12,7 +12,7 @@ Currently Moonkin’s talents are generally extremely close in power overall, bu
 ### Tier 15:
 {{< talent-row spec="balance" tier="15" src="beta" >}}
 
-{{< spell 202430 "Nature’s Balance" "beta" >}} (NB): Generates 2 Astral Power every 3 seconds and also makes your base Astral Power out of combat 50 rather than 0. Decent for sustained multi-target giving us constantly generating Astral Power. This talent, albeit niche, has the potential to be advantageous in Mythic+, notably those with long spans of downtime, giving the talent time to recharge your Astral Power to 50. Meaning it is also great in open world content as you’re regularly walking from place to place. Otherwise, Nature’s Balance tends to become your strongest damage option at 5+ targets.	
+{{< spell 202430 "Nature’s Balance" "beta" >}} (NB): Generates 2 Astral Power every 3 seconds and also makes your base Astral Power out of combat 50 rather than 0. Decent for sustained multi-target giving us constantly generating Astral Power. This talent, albeit niche, has the potential to be advantageous in Mythic+, notably those with long spans of downtime, giving the talent time to recharge your Astral Power to 50 (the out of combat Astral Power generation is greater than the in combat generation). Meaning it is also great in open world content as you’re regularly walking from place to place. Otherwise, Nature’s Balance tends to become your strongest damage option at 5+ targets.	
 
 {{< spell 202425 "Warrior of Elune" "beta" >}} (WoE): On activation, causes your next 3 {{< spell 194153 "Lunar Strikes" "beta" >}} to be instant cast and award 40% more astral power. This talent grants useful burst and priority target damage. Warrior of Elune is the best in the Tier 15 row for dealing with high movement encounters, generating 3 GCDs (Global Cooldowns) of movement and enough Astral Power for a spender. The three free Lunar Strikes should be used back to back regardless of if they’re empowered or not unless you’d overcap Astral Power.
 
@@ -23,7 +23,7 @@ Currently Moonkin’s talents are generally extremely close in power overall, bu
 
 {{< spell 16979 "Wild Charge" "beta" >}} (WC): When used, Wild Charge will activate a movement ability based on your current shapeshift form. In {{< spell 5487 "Bear Form" "beta" >}} and {{< spell 768 "Cat Form" "beta" >}}, this spell will cause you to charge or leap to the target. {{< spell 24858 "Moonkin Form" "beta" >}} and {{< spell 783 "Travel Form" "beta" >}} will fling you backwards or forwards respectively. Finally, {{< spell 276012 "Aquatic Form" "beta" >}} will increase your swim speed and if you lack a shapeshift form, you will fly to a targeted ally. The general choice in the row, we can use this ability to great effect in getting around the encounter. Having a very short cooldown, you should use Wild Charge to deal with most mechanics, generally through Moonkin Form, meaning it overshadows its competitors most of the time.
 
-{{< spell 252216 "Tiger Dash" "beta" >}} (TD): Shapeshifts you into {{< spell 768 "Cat Form" "beta" >}}, boosting your movement speed by 200% and gradually reducing overtime. Tiger Dash can be used for open world questing, otherwise TD is very niche for fights where you need to cover large distances very quickly in which {{< spell 16979 "Wild Charge" "beta" >}} wouldn’t do the trick. 
+{{< spell 252216 "Tiger Dash" "beta" >}} (TD): Shapeshifts you into {{< spell 768 "Cat Form" "beta" >}}, boosting your movement speed by 200% and gradually reducing overtime. Tiger Dash can be used for open world questing, otherwise TD is very niche for fights where you need to cover large distances very quickly in which {{< spell 16979 "Wild Charge" "beta" >}} wouldn’t do the trick such as orb running on G'huun. Likewise, Tiger Dash can be raid saving on fights such as Mythrax in which you have to get out of the raid with a debuff quickly to avoid wiping.
 
 {{< spell 108238 "Renewal" "beta" >}}: 90 second cooldown in which you heal for 30% of your maximum health. A decent choice if the other two options offer very little in comparison, such as a Patchwerk fight.
 
@@ -32,9 +32,9 @@ Currently Moonkin’s talents are generally extremely close in power overall, bu
 
 {{< spell 202157 "Feral Affinity" "beta" >}}: Besides nearly useless Feral abilities, Feral Affinity gives you 15% movement speed, which is only useful if the other two options are completely worthless.
 
-{{< spell 197491 "Guardian Affinity" "beta" >}}: As said before, Guardian Affinity talent is the go-to for most situations, granting generous survivability through the 6% damage reduction and decent healing through Frenzied Regeneration.
+{{< spell 197491 "Guardian Affinity" "beta" >}}: Guardian Affinity is a decent passive survivability talent, needing no change of play to gain the 6% mitigation. Generally will only see use if that 6% mitigation will stop you from being one shot.
 
-{{< spell 197492 "Restoration Affinity" "beta" >}}: Heals you for 3% of your maximum health every 5 seconds and allows you to access healing abilities such as Rejuvenation, Swiftmend, and Wild Growth. This can be a wise talent to take in open world or dungeons to keep your allies health topped off. With the nerfs to {{< spell 5487 "Bear Form" "beta" >}}, Restoration Affinity could see some use in a raiding environment as Swiftmend can instantly heal someone for 50% of their health, which is very useful for high damage fights when your healers can't keep up.  
+{{< spell 197492 "Restoration Affinity" "beta" >}}: Heals you for 3% of your maximum health every 5 seconds and allows you to access healing abilities such as Rejuvenation, Swiftmend, and Wild Growth. This can be a wise talent to take in open world or dungeons to keep your allies health topped off. Restoration Affinity is the go-to in a raiding environment as Swiftmend can instantly heal someone for 50% of their health, And Ysera's Gift's passive healing can be very useful for high damage fights when your healers can't keep up. 
 
 ### Tier 60:
 {{< talent-row spec="balance" tier="60" src="beta" >}}
@@ -59,24 +59,24 @@ Currently Moonkin’s talents are generally extremely close in power overall, bu
 
 {{< spell 202354 "Stellar Drift" "beta" >}} (SD): Allows you to freely move within {{< spell 191034 "Starfall’s" "beta" >}} radius and increases Starfalls damage, Stellar Drift is sadly outclassed by {{< spell 279620 "Twin Moons" "beta" >}} outside of niche situations
 
-{{< spell 279620 "Twin Moons" "beta" >}} ( TM): Causes your {{< spell 123413 "Moonfire" "beta" >}} to spread to one extra target. Twin Moons is generally the best on most raid bosses and in dungeons as it is nearly the highest damage on single target and is amazing for multi-target due to raw throughput and reducing our ramp time significantly.
+{{< spell 279620 "Twin Moons" "beta" >}} ( TM): Causes your {{< spell 123413 "Moonfire" "beta" >}} to spread to one extra target. Twin Moons is generally the best on most raid bosses and in dungeons as it is not far behind on single target compared to Stellar Flare and is amazing for multi-target due to raw throughput and reducing our ramp time significantly.
 
 {{< spell 202347 "Stellar Flare" "beta" >}} (StFl): A third DoT and the top single target option by a small margin, this spell falls off with any new targets being introduced. But, it can be decent if there are a low amount of spread targets.
 
 ### Tier 100:
 {{< talent-row spec="balance" tier="100" src="beta" >}}
 
-{{< spell 202342 "Shooting Stars" "beta" >}} (ShS): {{< spell 164812 "Moonfire" "beta" >}} and {{< spell 93402 "Sunfire" "beta" >}} have a chance to generate a shooting star which damages the enemy and grants you 4 Astral Power. This ability is the best pure single target and two target option. There is a hidden diminishing return attached to Shooting Stars which is why it loses value with more targets unless they are spread.
+{{< spell 202342 "Shooting Stars" "beta" >}} (ShS): {{< spell 164812 "Moonfire" "beta" >}} and {{< spell 93402 "Sunfire" "beta" >}} have a chance to generate a shooting star which damages the enemy and grants you 4 Astral Power. This ability is the best pure single target and two target option and can be good on many spread targets. There is a hidden diminishing return attached to Shooting Stars which is why it loses value with more targets relative to other talents.
 
-{{< spell 202770 "Fury of Elune" "beta" >}} (FoE): Our ultimate burst ability, awarding unmatched burst in a short 1 minute cooldown in the form of a tremendous laser which cleaves every target in an 8 yard radius. Any time there is 3+ targets Fury of Elune will tend to be the best option unless the targets aren’t stacked. In addition to doing a lot of damage, FoE grants you 40 Astral Power which can keep the burst going, generally making spell the go-to for heavy burst as well.
+{{< spell 202770 "Fury of Elune" "beta" >}} (FoE): Our ultimate burst ability, awarding unmatched burst in a short 1 minute cooldown in the form of a tremendous laser which cleaves every target in an 8 yard radius. Any time there is 3+ targets Fury of Elune will tend to be the best option unless the targets aren’t stacked. In addition to doing a lot of damage, FoE grants you 40 Astral Power which can keep the burst going, generally making the spell the go-to for heavy burst as well.
 
 {{< spell 274281 "New Moon" "beta" >}} (Moons): An ability which cycles through 3 types of moons that increase in power, cast time, and Astral Power generation. The weakest option in the row, Moons lack any real niche and just aren’t worth taking in any situation.
 
 
 ### General Single Target Build:
 
-{{< talents spec="balance" src="beta" recommend="123,223,132,233,132,123,322" >}}
+{{< talents spec="balance" src="beta" recommend="223,223,223,233,132,123,322" >}}
 
 ### General AoE Build:
 
-{{< talents spec="balance" src="beta" recommend="232,223,132,233,233,231,231" >}}
+{{< talents spec="balance" src="beta" recommend="232,223,223,233,233,231,231" >}}


### PR DESCRIPTION
- Clarified Nature's Balance out of combat regen
- Changed Guardian Affinity and Restoration Affinity explanation
- Fixed FoE grammar
- Clarified ShS to lose value on more targets regardless of spread or not
- Suggested Talents, recommended Resto Affinity and made Feral Affinity yellow
- Clarified Tiger Dash to be useful on fights where you must cover large distances
- Clarified TM to say it's close to Stellar Flare on ST
