### PR TITLE
Fix 'Most Recent' sorting in series asides.

### DIFF
--- a/themes/dg-theme/layouts/partials/series-toc.html
+++ b/themes/dg-theme/layouts/partials/series-toc.html
@@ -12,7 +12,7 @@
     {{ end }}
   </p>
   <ul>
-    {{ range (last 5 $seriesPages.Pages) }}
+    {{ range (first 5 $seriesPages.Pages) }}
       {{ if (eq $current .) }}
       <li class="active">{{ or .Params.series_title .Title }}</li>
       {{ else }}


### PR DESCRIPTION
Series are sorted by descending date, so we should pull the 5 most recent from the beginning of the list instead of the end of the list.