### PR TITLE
Allow embedded HTML in new markdown engine

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,6 +6,9 @@ enableGitInfo = true
 
 [blackfriday]
   hrefTargetBlank = true
+  
+[markup.goldmark.renderer]
+  unsafe= true
 
 [params]
   enableElune = true

--- a/config.toml
+++ b/config.toml
@@ -7,8 +7,10 @@ enableGitInfo = true
 [blackfriday]
   hrefTargetBlank = true
   
-[markup.goldmark.renderer]
-  unsafe= true
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
 
 [params]
   enableElune = true


### PR DESCRIPTION
Goldmark (the default markdown parser since Hugo 0.60) disables embedded HTML in documents by default. This setting turns it back on.