### PR TITLE
Post-local sidebar

### DIFF
--- a/content/2021-05-15-sidebar-test.md
+++ b/content/2021-05-15-sidebar-test.md
@@ -1,0 +1,30 @@
+---
+date: '2021-05-15'
+authors: ["faide"]
+published: false
+patch: "9.1"
+title: Sidebar test
+sidebarTitle: "Additional Resources"
+sidebarContents: |
+  This is a sidebar test.
+
+  You can put *any* **markdown** in ~~here~~.
+
+  [Even links work!](https://google.com)
+
+  - Here's 
+  - a
+  - list
+  - of 
+  - things
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam a dolor orci. Cras sodales lorem maximus tellus semper aliquam. Suspendisse sagittis, quam eget semper bibendum, dolor erat tristique quam, vitae sodales orci risus ultrices magna. Curabitur quam tellus, maximus auctor nisi sed, venenatis fringilla nulla. Aliquam in enim arcu. Etiam nec tempor dui. Vivamus convallis justo diam, at elementum metus finibus eu. Etiam efficitur consequat consequat. Nullam consectetur sollicitudin nunc, non lobortis diam efficitur vel. Morbi suscipit ut est auctor consequat. Donec nec massa ullamcorper, aliquam diam in, congue diam. Aliquam rutrum mauris in enim mattis, et fringilla neque blandit. Fusce vel magna arcu. Duis porta ex vel sem elementum, condimentum pellentesque lectus dapibus.
+
+Nunc et ultrices elit, sit amet consectetur magna. Nulla arcu ex, tincidunt vitae euismod ut, blandit sed nulla. Morbi nec orci tristique, posuere felis ut, dapibus velit. Aenean ut enim placerat, fringilla lectus et, luctus arcu. Etiam vitae tortor vitae turpis dignissim dictum et eget erat. Duis at ultricies urna, laoreet suscipit lacus. Praesent interdum rhoncus efficitur. Nullam quam arcu, volutpat eu neque luctus, fermentum egestas nisl. Fusce ornare lacus neque, ut posuere nisi blandit id. Ut ut est blandit, lacinia leo eu, dapibus tortor. Donec varius euismod lacus porta euismod. Duis ac eros eget lectus tristique vehicula. Mauris vel felis libero.
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Phasellus iaculis sapien metus, in luctus mauris suscipit ac. Fusce tincidunt dapibus feugiat. Mauris lectus urna, finibus sit amet vehicula et, tincidunt vitae leo. Morbi sed sollicitudin lacus, eget tempor purus. Curabitur sollicitudin augue nec facilisis viverra. Integer at feugiat diam. Donec mi quam, finibus eu massa ac, malesuada tempus nisl. Aenean lacus erat, blandit ac mauris et, pulvinar tempor lectus. Nam tristique congue purus, at venenatis est molestie sit amet. Morbi mattis magna arcu, ac tincidunt massa faucibus et. Donec diam est, pulvinar a felis id, mollis euismod lacus. Donec bibendum turpis at ullamcorper molestie. Morbi efficitur urna quis enim faucibus, at volutpat arcu ornare. Morbi tincidunt tellus a sem rhoncus ullamcorper.
+
+Quisque nec condimentum neque, a sollicitudin velit. Ut sagittis iaculis hendrerit. Nulla pellentesque dictum lectus, eget bibendum urna imperdiet et. Cras in purus nisl. In rutrum sapien dui, eu aliquam leo condimentum et. Maecenas odio libero, aliquam eget turpis sit amet, vestibulum gravida erat. Ut viverra lorem non sodales feugiat. Praesent velit metus, interdum vel sagittis euismod, posuere finibus ligula. Nullam elementum leo sit amet nibh molestie vehicula.
+
+Cras nec tristique quam, at fringilla lectus. Vestibulum posuere magna id quam viverra commodo. Nunc vel suscipit erat. Nulla fringilla interdum tellus. Vivamus scelerisque suscipit libero nec finibus. Fusce cursus ut ipsum sodales consectetur. Vestibulum laoreet sollicitudin pharetra. Donec id sem mi. Nulla nec venenatis risus, a tincidunt nibh. 

--- a/themes/dg-theme/layouts/_default/single.html
+++ b/themes/dg-theme/layouts/_default/single.html
@@ -32,14 +32,14 @@
         {{ partial "series-toc.html" . }}
       </section>
     {{ end }}
+    {{ partial "breadcrumb.html" . }}
+    {{ partial "post-header.html" . }}
+    {{ partial "post-content.html" . }}
     {{ if .Params.sidebarContents }}
       <section class="section-overview toc">
         {{ partial "post-sidebar.html" . }}
       </section>
     {{ end }}
-    {{ partial "breadcrumb.html" . }}
-    {{ partial "post-header.html" . }}
-    {{ partial "post-content.html" . }}
     {{ partial "post-footer.html" . }}
   </article>
 </main>

--- a/themes/dg-theme/layouts/_default/single.html
+++ b/themes/dg-theme/layouts/_default/single.html
@@ -16,7 +16,7 @@
 {{ define "main" }}
 {{ partial "header.html" . }}
 <main class="main">
-  <article class="article main-wrapper{{ if (or .Parent.Params.showsectiontoc .Params.series .Params.showtoc) }} with-sidebar{{ end }}">
+  <article class="article main-wrapper{{ if (or .Parent.Params.showsectiontoc .Params.series .Params.showtoc .Params.sidebarContents) }} with-sidebar{{ end }}">
     {{ if .Parent.Params.showsectiontoc }}
       <section class="section-overview toc">
         {{ partial "section-toc.html" . }}
@@ -30,6 +30,11 @@
     {{ if .Params.series }}
       <section class="section-overview toc">
         {{ partial "series-toc.html" . }}
+      </section>
+    {{ end }}
+    {{ if .Params.sidebarContents }}
+      <section class="section-overview toc">
+        {{ partial "post-sidebar.html" . }}
       </section>
     {{ end }}
     {{ partial "breadcrumb.html" . }}

--- a/themes/dg-theme/layouts/partials/post-sidebar.html
+++ b/themes/dg-theme/layouts/partials/post-sidebar.html
@@ -1,0 +1,4 @@
+<div class="sticky=toc">
+  <h1>{{ with .Params.sidebarTitle }}{{ . }}{{ else }}Sidebar{{ end }}</h1>
+  {{ .Params.sidebarContents | markdownify }}
+</div>


### PR DESCRIPTION
Adds support for a sidebar with contents that can be declared by the post.

The following frontmatter variables are available:
 - `sidebarContents` : a string of markdown to be rendered in the sidebar
 - `sidebarTitle` : What to display as the title of the sidebar. Defaults to "Sidebar".