### PR TITLE
Fixes Wordwrap for Long Links on Smaller Viewports

### DIFF
--- a/themes/dg-theme/assets/css/main.scss
+++ b/themes/dg-theme/assets/css/main.scss
@@ -7,10 +7,6 @@ $screenheight-short: 900px;
 a, a:hover, a:visited, a:active {
   color: inherit;
   text-decoration: none;
-  white-space: pre-wrap; /* CSS3 */    
-  white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
-  white-space: -pre-wrap; /* Opera 4-6 */    
-  white-space: -o-pre-wrap; /* Opera 7 */    
   word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
 

--- a/themes/dg-theme/assets/css/main.scss
+++ b/themes/dg-theme/assets/css/main.scss
@@ -7,6 +7,11 @@ $screenheight-short: 900px;
 a, a:hover, a:visited, a:active {
   color: inherit;
   text-decoration: none;
+  white-space: pre-wrap; /* CSS3 */    
+  white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
+  white-space: -pre-wrap; /* Opera 4-6 */    
+  white-space: -o-pre-wrap; /* Opera 7 */    
+  word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
 
 html {

--- a/themes/dg-theme/assets/css/main.scss
+++ b/themes/dg-theme/assets/css/main.scss
@@ -7,7 +7,7 @@ $screenheight-short: 900px;
 a, a:hover, a:visited, a:active {
   color: inherit;
   text-decoration: none;
-  word-wrap: break-word; /* Internet Explorer 5.5+ */
+  word-wrap: anywhere; /* Internet Explorer 5.5+ */
 }
 
 html {


### PR DESCRIPTION
Now all links (i.e. talent links) wrap correctly on mobile