### PR TITLE
[Feral] More support for off-meta talents

### DIFF
--- a/static/sims/cat/feral.txt
+++ b/static/sims/cat/feral.txt
@@ -2,23 +2,28 @@
 actions.precombat=flask
 actions.precombat+=/food
 actions.precombat+=/augmentation
+# Snapshot raid buffed stats before combat begins and pre-potting is done.
 actions.precombat+=/snapshot_stats
+# Executed before combat begins. Accepts non-harmful actions only.
 actions.precombat+=/cat_form,if=!buff.cat_form.up
 actions.precombat+=/heart_of_the_wild
 actions.precombat+=/use_item,name=algethar_puzzle_box
 actions.precombat+=/prowl,if=!buff.prowl.up
 
-actions=prowl,if=buff.bs_inc.down&!buff.prowl.up
+# Executed every time the actor is available.
+actions=prowl,if=(buff.bs_inc.down|!in_combat)&!buff.prowl.up
 actions+=/cat_form,if=!buff.cat_form.up
-# <a href='https://www.wowhead.com/spell=10060/power-infusion'>Power Infusion</a> does not line up very well with <a href='https://www.wowhead.com/spell=106951/berserk'>Berserk nor <a href='https://www.wowhead.com/spell=102543/incarnation-avatar-of-ashamane'>Incarnation</a> and <a href='https://www.wowhead.com/spell=323764/convoke-the-spirits?spellModifier=768'>Convoke</a> doesn't benefit much from haste.
+# <a href='https://www.wowhead.com/spell=10060/power-infusion'>Power Infusion</a> does not line up very well with <a href='https://www.wowhead.com/spell=106951/berserk'>Berserk</a> nor <a href='https://www.wowhead.com/spell=102543/incarnation-avatar-of-ashamane'>Incarnation</a> and <a href='https://www.wowhead.com/spell=323764/convoke-the-spirits?spellModifier=768'>Convoke</a> doesn't benefit much from haste.
 actions+=/invoke_external_buff,name=power_infusion
 actions+=/call_action_list,name=variables
 actions+=/tigers_fury,if=!talent.convoke_the_spirits.enabled&(!buff.tigers_fury.up|energy.deficit>65)
 actions+=/tigers_fury,if=talent.convoke_the_spirits.enabled&(!variable.lastConvoke|(variable.lastConvoke&!buff.tigers_fury.up))
 actions+=/rake,target_if=1.4*persistent_multiplier>dot.rake.pmultiplier,if=buff.prowl.up|buff.shadowmeld.up
 actions+=/auto_attack,if=!buff.prowl.up&!buff.shadowmeld.up
-actions+=/natures_vigil
-actions+=/adaptive_swarm,target_if=((!dot.adaptive_swarm_damage.ticking|dot.adaptive_swarm_damage.remains<2)&(dot.adaptive_swarm_damage.stack<3|!dot.adaptive_swarm_heal.stack>1)&!action.adaptive_swarm_heal.in_flight&!action.adaptive_swarm_damage.in_flight&!action.adaptive_swarm.in_flight)&target.time_to_die>5|active_enemies>2&!dot.adaptive_swarm_damage.ticking&energy<35&target.time_to_die>5,if=!(variable.need_bt&active_bt_triggers=2)
+actions+=/natures_vigil,if=in_combat
+actions+=/adaptive_swarm,target_if=((!dot.adaptive_swarm_damage.ticking|dot.adaptive_swarm_damage.remains<2)&(dot.adaptive_swarm_damage.stack<3)&!action.adaptive_swarm_damage.in_flight&!action.adaptive_swarm.in_flight)&target.time_to_die>5,if=!(variable.need_bt&active_bt_triggers=2)&(!talent.unbridled_swarm.enabled|spell_targets.swipe_cat=1)
+# in reality, with unbridled talented adaptive swarm should be targeting allies out of combat, and often in single target too. This isn't supported by simc at time of writing though, so will have to settle with just this
+actions+=/adaptive_swarm,target_if=max:(dot.adaptive_swarm_damage.stack*dot.adaptive_swarm_damage.stack<3*time_to_die),if=dot.adaptive_swarm_damage.stack<3&talent.unbridled_swarm.enabled&spell_targets.swipe_cat>1&!(variable.need_bt&active_bt_triggers=2)
 actions+=/call_action_list,name=cooldown
 actions+=/feral_frenzy,target_if=max:target.time_to_die,if=combo_points<2|combo_points<3&buff.bs_inc.up
 actions+=/ferocious_bite,target_if=max:target.time_to_die,if=buff.apex_predators_craving.up&(spell_targets.swipe_cat=1|!talent.primal_wrath.enabled|!buff.sabertooth.up)&!(variable.need_bt&active_bt_triggers=2)
@@ -27,8 +32,9 @@ actions+=/wait,sec=combo_points=5,if=combo_points=4&buff.predator_revealed.react
 # its acceptable to proc bt when at 4cps in single target for a small gain (0.1-0.2% with t30 4p)
 actions+=/call_action_list,name=finisher,if=combo_points>=4&!(combo_points=4&buff.bloodtalons.stack<=1&active_bt_triggers=2&spell_targets.swipe_cat=1)
 actions+=/call_action_list,name=bloodtalons,if=variable.need_bt&!buff.bs_inc.up&combo_points<5
-actions+=/run_action_list,name=aoe_builder,if=spell_targets.swipe_cat>1&talent.primal_wrath.enabled
-actions+=/call_action_list,name=builder,if=combo_points<5&!buff.bs_inc.up
+actions+=/call_action_list,name=aoe_builder,if=spell_targets.swipe_cat>1&talent.primal_wrath.enabled
+actions+=/call_action_list,name=builder,if=!buff.bs_inc.up&combo_points<5
+actions+=/regrowth,if=energy<20&buff.predatory_swiftness.up&!buff.clearcasting.up&variable.regrowth
 
 # avoid capping brs charges, and in the event of adds, offload charges within reason
 actions.aoe_builder=brutal_slash,target_if=min:target.time_to_die,if=cooldown.brutal_slash.full_recharge_time<4|target.time_to_die<5
@@ -46,7 +52,7 @@ actions.aoe_builder+=/moonfire_cat,target_if=refreshable,if=spell_targets.swipe_
 actions.aoe_builder+=/swipe_cat
 actions.aoe_builder+=/moonfire_cat,target_if=refreshable
 # if we have brs and nothing better to cast, check if thrash DD beats shred (or if SA is up)
-actions.aoe_builder+=/shred,target_if=max:target.time_to_die,if=action.shred.damage>action.thrash_cat.damage&!buff.sudden_ambush.up
+actions.aoe_builder+=/shred,target_if=max:target.time_to_die,if=action.shred.damage>action.thrash_cat.damage&!buff.sudden_ambush.up&!(variable.lazy_swipe&talent.wild_slashes)
 actions.aoe_builder+=/thrash_cat
 
 actions.berserk=ferocious_bite,target_if=max:target.time_to_die,if=combo_points=5&dot.rip.remains>8&variable.zerk_biteweave&spell_targets.swipe_cat>1
@@ -68,7 +74,7 @@ actions.berserk+=/moonfire_cat,if=refreshable
 actions.berserk+=/brutal_slash,if=cooldown.brutal_slash.charges>1
 actions.berserk+=/shred
 
-actions.bloodtalons+=/brutal_slash,target_if=min:target.time_to_die,if=(cooldown.brutal_slash.full_recharge_time<4|target.time_to_die<5)&(buff.bt_brutal_slash.down&(buff.bs_inc.up|variable.need_bt))
+actions.bloodtalons=brutal_slash,target_if=min:target.time_to_die,if=(cooldown.brutal_slash.full_recharge_time<4|target.time_to_die<5)&(buff.bt_brutal_slash.down&(buff.bs_inc.up|variable.need_bt))
 actions.bloodtalons+=/prowl,if=action.rake.ready&gcd.remains=0&!buff.sudden_ambush.up&(dot.rake.refreshable|dot.rake.pmultiplier<1.4)&!buff.shadowmeld.up&buff.bt_rake.down&!buff.prowl.up&!buff.apex_predators_craving.up
 actions.bloodtalons+=/shadowmeld,if=action.rake.ready&!buff.sudden_ambush.up&(dot.rake.refreshable|dot.rake.pmultiplier<1.4)&!buff.prowl.up&buff.bt_rake.down&cooldown.feral_frenzy.remains<44&!buff.apex_predators_craving.up
 actions.bloodtalons+=/rake,target_if=max:druid.rake.ticks_gained_on_refresh,if=(refreshable|buff.sudden_ambush.up&persistent_multiplier>dot.rake.pmultiplier)&buff.bt_rake.down
@@ -78,14 +84,16 @@ actions.bloodtalons+=/thrash_cat,target_if=refreshable,if=buff.bt_thrash.down&bu
 actions.bloodtalons+=/brutal_slash,if=buff.bt_brutal_slash.down
 actions.bloodtalons+=/moonfire_cat,if=refreshable&buff.bt_moonfire.down&spell_targets.swipe_cat=1
 actions.bloodtalons+=/thrash_cat,target_if=refreshable,if=buff.bt_thrash.down&!talent.thrashing_claws.enabled
-actions.bloodtalons+=/shred,if=buff.bt_shred.down&spell_targets.swipe_cat=1&!talent.wild_slashes.enabled
+actions.bloodtalons+=/shred,if=buff.bt_shred.down&spell_targets.swipe_cat=1&(!talent.wild_slashes.enabled|(!debuff.dire_fixation.up&talent.dire_fixation.enabled))
 actions.bloodtalons+=/swipe_cat,if=buff.bt_swipe.down&talent.wild_slashes.enabled
 actions.bloodtalons+=/moonfire_cat,target_if=max:ticks_gained_on_refresh,if=buff.bt_moonfire.down&spell_targets.swipe_cat<5
 actions.bloodtalons+=/swipe_cat,if=buff.bt_swipe.down
 actions.bloodtalons+=/moonfire_cat,target_if=max:ticks_gained_on_refresh,if=buff.bt_moonfire.down
 # If we have BrS and nothing better to cast, check if shred beats thrash DD (or if SA is up)
-actions.bloodtalons+=/shred,target_if=max:target.time_to_die,if=action.shred.damage>action.thrash_cat.damage&buff.bt_shred.down&!buff.sudden_ambush.up
+actions.bloodtalons+=/shred,target_if=max:target.time_to_die,if=action.shred.damage>action.thrash_cat.damage&buff.bt_shred.down&!buff.sudden_ambush.up&!(variable.lazy_swipe&talent.wild_slashes)
 actions.bloodtalons+=/thrash_cat,if=buff.bt_thrash.down
+# this line is for the lazy-swipe build only, basically the idea is to only use swipe thrash and rake in aoe. This just finds the best reapplication if you really need 3rd builder for bt
+actions.bloodtalons+=/rake,target_if=min:(25*(persistent_multiplier<dot.rake.pmultiplier)+dot.rake.remains),if=buff.bt_rake.down&variable.lazy_swipe&talent.wild_slashes
 
 actions.builder=run_action_list,name=clearcasting,if=buff.clearcasting.react
 actions.builder+=/brutal_slash,if=cooldown.brutal_slash.full_recharge_time<4
@@ -98,7 +106,7 @@ actions.builder+=/run_action_list,name=clearcasting,if=buff.clearcasting.react
 actions.builder+=/moonfire_cat,target_if=refreshable
 actions.builder+=/thrash_cat,target_if=refreshable&!talent.thrashing_claws.enabled
 actions.builder+=/brutal_slash
-actions.builder+=/swipe_cat,if=spell_targets.swipe_cat>1|talent.wild_slashes.enabled
+actions.builder+=/swipe_cat,if=spell_targets.swipe_cat>1|(talent.wild_slashes.enabled&(debuff.dire_fixation.up|!talent.dire_fixation.enabled))
 actions.builder+=/shred
 
 actions.clearcasting=thrash_cat,if=refreshable&!talent.thrashing_claws.enabled
@@ -112,13 +120,14 @@ actions.cooldown+=/use_item,name=algethar_puzzle_box,if=variable.align_3minutes&
 actions.cooldown+=/incarnation,target_if=max:target.time_to_die,if=(target.time_to_die<fight_remains&target.time_to_die>25)|target.time_to_die=fight_remains
 actions.cooldown+=/berserk,target_if=max:target.time_to_die,if=((target.time_to_die<fight_remains&target.time_to_die>18)|target.time_to_die=fight_remains)&((!variable.lastZerk)|(fight_remains<23)|(variable.lastZerk&!variable.lastConvoke)|(variable.lastConvoke&cooldown.convoke_the_spirits.remains<10))
 actions.cooldown+=/berserking,if=!variable.align_3minutes|buff.bs_inc.up
+actions.cooldown+=/use_item,name=mirror_of_fractured_tomorrows|irideus_fragment,if=!variable.align_3minutes|buff.bs_inc.up|(variable.lastConvoke&!variable.lastZerk&cooldown.convoke_the_spirits.remains=0)
 actions.cooldown+=/potion,if=buff.bs_inc.up|fight_remains<32|(fight_remains<cooldown.bs_inc.remains&variable.lastConvoke&cooldown.convoke_the_spirits.remains<10)
 # checks to make sure you can actually fit convoke into the pull.
 actions.cooldown+=/convoke_the_spirits,target_if=max:target.time_to_die,if=((target.time_to_die<fight_remains&target.time_to_die>5)|target.time_to_die=fight_remains)&(fight_remains<5|(dot.rip.remains>5&buff.tigers_fury.up&(combo_points<2|(buff.bs_inc.up&combo_points=2))&(!variable.lastConvoke|!variable.lastZerk|buff.bs_inc.up)))
 actions.cooldown+=/use_item,name=manic_grieftorch,target_if=max:target.time_to_die,if=energy.deficit>40
 actions.cooldown+=/use_items
 
-actions.finisher=primal_wrath,if=((dot.primal_wrath.refreshable&!talent.circle_of_life_and_death.enabled)|dot.primal_wrath.remains<6|talent.tear_open_wounds.enabled)&spell_targets.primal_wrath>1&talent.primal_wrath.enabled
+actions.finisher=primal_wrath,if=((dot.primal_wrath.refreshable&!talent.circle_of_life_and_death.enabled)|dot.primal_wrath.remains<6|(talent.tear_open_wounds.enabled|(spell_targets.swipe_cat>4&!talent.rampant_ferocity.enabled)))&spell_targets.primal_wrath>1&talent.primal_wrath.enabled
 actions.finisher+=/rip,target_if=refreshable
 actions.finisher+=/pool_resource,for_next=1,if=!action.tigers_fury.ready&buff.apex_predators_craving.down
 actions.finisher+=/ferocious_bite,max_energy=1,target_if=max:target.time_to_die,if=buff.apex_predators_craving.down&(!buff.bs_inc.up|(buff.bs_inc.up&!talent.soul_of_the_forest.enabled))
@@ -129,3 +138,5 @@ actions.variables+=/variable,name=align_3minutes,value=spell_targets.swipe_cat=1
 actions.variables+=/variable,name=lastConvoke,value=fight_remains>cooldown.convoke_the_spirits.remains+3&((talent.ashamanes_guidance.enabled&fight_remains<(cooldown.convoke_the_spirits.remains+60))|(!talent.ashamanes_guidance.enabled&fight_remains<(cooldown.convoke_the_spirits.remains+120)))
 actions.variables+=/variable,name=lastZerk,value=fight_remains>(30+(cooldown.bs_inc.remains%1.6))&((talent.berserk_heart_of_the_lion.enabled&fight_remains<(90+(cooldown.bs_inc.remains%1.6)))|(!talent.berserk_heart_of_the_lion.enabled&fight_remains<(180+cooldown.bs_inc.remains)))
 actions.variables+=/variable,name=zerk_biteweave,op=reset
+actions.variables+=/variable,name=regrowth,op=reset
+actions.variable+=/variable,name=lazy_swipe,op=reset


### PR DESCRIPTION
Smarter targeting when using Unbridled Swarm
In Wild Slashes builds, shred has higher priority if Dire Fixation is talented, but not currently applied In no tear open wounds + no rampant ferocity builds, spam primal wrath above 4 targets in aoe instead of only refreshing when low duration Line up 3 min trinkets with incarn/convoke in single target.

Add 2 new variable options:
1. apl_variable.regrowth When set to 1, the apl will cast regrowth when there are free gcds to do so + predatory swiftness is available

2. apl_variable.lazy_swipe When set to 1, the apl will do an inferior but simpler rotation in aoe, where shred does not get casted, instead opting to proc bt via swipe, rake and thrash only.