### PR TITLE
[Feral] Fix Convoke and add Renewal

### DIFF
--- a/static/sims/cat/feral.txt
+++ b/static/sims/cat/feral.txt
@@ -9,6 +9,7 @@ actions.precombat+=/cat_form,if=!buff.cat_form.up
 actions.precombat+=/heart_of_the_wild
 actions.precombat+=/use_item,name=algethar_puzzle_box
 actions.precombat+=/prowl,if=!buff.prowl.up
+actions.precombat+=/use_item,name=beacon_to_the_beyond,if=!(trinket.1.is.dragonfire_bomb_dispenser|trinket.2.is.dragonfire_bomb_dispenser)
 
 # Executed every time the actor is available.
 actions=prowl,if=(buff.bs_inc.down|!in_combat)&!buff.prowl.up
@@ -16,16 +17,17 @@ actions+=/cat_form,if=!buff.cat_form.up
 # <a href='https://www.wowhead.com/spell=10060/power-infusion'>Power Infusion</a> does not line up very well with <a href='https://www.wowhead.com/spell=106951/berserk'>Berserk</a> nor <a href='https://www.wowhead.com/spell=102543/incarnation-avatar-of-ashamane'>Incarnation</a> and <a href='https://www.wowhead.com/spell=323764/convoke-the-spirits?spellModifier=768'>Convoke</a> doesn't benefit much from haste.
 actions+=/invoke_external_buff,name=power_infusion
 actions+=/call_action_list,name=variables
-actions+=/tigers_fury,if=!talent.convoke_the_spirits.enabled&(!buff.tigers_fury.up|energy.deficit>65)
-actions+=/tigers_fury,if=talent.convoke_the_spirits.enabled&(!variable.lastConvoke|(variable.lastConvoke&!buff.tigers_fury.up))
-actions+=/rake,target_if=1.4*persistent_multiplier>dot.rake.pmultiplier,if=buff.prowl.up|buff.shadowmeld.up
+actions+=/tigers_fury,target_if=min:target.time_to_die,if=talent.convoke_the_spirits.enabled|!talent.convoke_the_spirits.enabled&(!buff.tigers_fury.up|energy.deficit>65)|(target.time_to_die<15&talent.predator.enabled)
+actions+=/rake,target_if=persistent_multiplier>dot.rake.pmultiplier,if=buff.prowl.up|buff.shadowmeld.up
 actions+=/auto_attack,if=!buff.prowl.up&!buff.shadowmeld.up
-actions+=/natures_vigil,if=in_combat
+actions+=/natures_vigil,if=spell_targets.swipe_cat>0
+actions+=/renewal,if=variable.regrowth
+actions+=/adaptive_swarm,target=self,if=talent.unbridled_swarm&spell_targets.swipe_cat<=1&dot.adaptive_swarm_heal.stack<4&dot.adaptive_swarm_heal.remains>4
 actions+=/adaptive_swarm,target_if=((!dot.adaptive_swarm_damage.ticking|dot.adaptive_swarm_damage.remains<2)&(dot.adaptive_swarm_damage.stack<3)&!action.adaptive_swarm_damage.in_flight&!action.adaptive_swarm.in_flight)&target.time_to_die>5,if=!(variable.need_bt&active_bt_triggers=2)&(!talent.unbridled_swarm.enabled|spell_targets.swipe_cat=1)
 # in reality, with unbridled talented adaptive swarm should be targeting allies out of combat, and often in single target too. This isn't supported by simc at time of writing though, so will have to settle with just this
-actions+=/adaptive_swarm,target_if=max:(dot.adaptive_swarm_damage.stack*dot.adaptive_swarm_damage.stack<3*time_to_die),if=dot.adaptive_swarm_damage.stack<3&talent.unbridled_swarm.enabled&spell_targets.swipe_cat>1&!(variable.need_bt&active_bt_triggers=2)
+actions+=/adaptive_swarm,target_if=max:((1+dot.adaptive_swarm_damage.stack)*dot.adaptive_swarm_damage.stack<3*time_to_die),if=dot.adaptive_swarm_damage.stack<3&talent.unbridled_swarm.enabled&spell_targets.swipe_cat>1&!(variable.need_bt&active_bt_triggers=2)
 actions+=/call_action_list,name=cooldown
-actions+=/feral_frenzy,target_if=max:target.time_to_die,if=combo_points<2|combo_points<3&buff.bs_inc.up
+actions+=/feral_frenzy,target_if=max:target.time_to_die,if=((talent.dire_fixation.enabled&debuff.dire_fixation.up)|!talent.dire_fixation.enabled|spell_targets.swipe_cat>1)&(combo_points<2|combo_points<3&buff.bs_inc.up|time<10)
 actions+=/ferocious_bite,target_if=max:target.time_to_die,if=buff.apex_predators_craving.up&(spell_targets.swipe_cat=1|!talent.primal_wrath.enabled|!buff.sabertooth.up)&!(variable.need_bt&active_bt_triggers=2)
 actions+=/call_action_list,name=berserk,if=buff.bs_inc.up
 actions+=/wait,sec=combo_points=5,if=combo_points=4&buff.predator_revealed.react&energy.deficit>40&spell_targets.swipe_cat=1
@@ -34,7 +36,7 @@ actions+=/call_action_list,name=finisher,if=combo_points>=4&!(combo_points=4&buf
 actions+=/call_action_list,name=bloodtalons,if=variable.need_bt&!buff.bs_inc.up&combo_points<5
 actions+=/call_action_list,name=aoe_builder,if=spell_targets.swipe_cat>1&talent.primal_wrath.enabled
 actions+=/call_action_list,name=builder,if=!buff.bs_inc.up&combo_points<5
-actions+=/regrowth,if=energy<20&buff.predatory_swiftness.up&!buff.clearcasting.up&variable.regrowth
+actions+=/regrowth,if=energy<25&buff.predatory_swiftness.up&!buff.clearcasting.up&variable.regrowth
 
 # avoid capping brs charges, and in the event of adds, offload charges within reason
 actions.aoe_builder=brutal_slash,target_if=min:target.time_to_die,if=cooldown.brutal_slash.full_recharge_time<4|target.time_to_die<5
@@ -48,11 +50,12 @@ actions.aoe_builder+=/rake,target_if=max:druid.rake.ticks_gained_on_refresh,if=b
 actions.aoe_builder+=/rake,target_if=buff.sudden_ambush.up&persistent_multiplier>dot.rake.pmultiplier|refreshable
 actions.aoe_builder+=/thrash_cat,target_if=refreshable
 actions.aoe_builder+=/brutal_slash
-actions.aoe_builder+=/moonfire_cat,target_if=refreshable,if=spell_targets.swipe_cat<5
+# prio targets with swarm debuff for moonfire
+actions.aoe_builder+=/moonfire_cat,target_if=max:(3*refreshable)+dot.adaptive_swarm_damage.ticking,if=spell_targets.swipe_cat<5&dot.moonfire.refreshable
 actions.aoe_builder+=/swipe_cat
-actions.aoe_builder+=/moonfire_cat,target_if=refreshable
-# if we have brs and nothing better to cast, check if thrash DD beats shred (or if SA is up)
-actions.aoe_builder+=/shred,target_if=max:target.time_to_die,if=action.shred.damage>action.thrash_cat.damage&!buff.sudden_ambush.up&!(variable.lazy_swipe&talent.wild_slashes)
+actions.aoe_builder+=/moonfire_cat,target_if=max:(3*refreshable)+dot.adaptive_swarm_damage.ticking,if=dot.moonfire.refreshable
+# if we have brs and nothing better to cast, refresh thrash early at 4+ targets unless dire fixation is talented
+actions.aoe_builder+=/shred,target_if=max:target.time_to_die,if=(spell_targets.swipe_cat<4|talent.dire_fixation.enabled)&!buff.sudden_ambush.up&!(variable.lazy_swipe&talent.wild_slashes)
 actions.aoe_builder+=/thrash_cat
 
 actions.berserk=ferocious_bite,target_if=max:target.time_to_die,if=combo_points=5&dot.rip.remains>8&variable.zerk_biteweave&spell_targets.swipe_cat>1
@@ -63,9 +66,9 @@ actions.berserk+=/call_action_list,name=bloodtalons,if=spell_targets.swipe_cat>1
 # go into stealth to buff rake snapshot-- feral frenzy line is to eliminate an edge case involving ff being casted instead due to higher prio
 actions.berserk+=/prowl,if=!(buff.bt_rake.up&active_bt_triggers=2)&(action.rake.ready&gcd.remains=0&!buff.sudden_ambush.up&(dot.rake.refreshable|dot.rake.pmultiplier<1.4)&!buff.shadowmeld.up&cooldown.feral_frenzy.remains<44&!buff.apex_predators_craving.up)
 actions.berserk+=/shadowmeld,if=!(buff.bt_rake.up&active_bt_triggers=2)&action.rake.ready&!buff.sudden_ambush.up&(dot.rake.refreshable|dot.rake.pmultiplier<1.4)&!buff.prowl.up&!buff.apex_predators_craving.up
-actions.berserk+=/rake,if=!(buff.bt_rake.up&active_bt_triggers=2)&(refreshable|(buff.sudden_ambush.up&persistent_multiplier>dot.rake.pmultiplier&!dot.rake.refreshable))
+actions.berserk+=/rake,if=!(buff.bt_rake.up&active_bt_triggers=2)&(refreshable|(buff.sudden_ambush.up&persistent_multiplier>dot.rake.pmultiplier))
 # in single target, you just proc bt when an opportunity arises
-actions.berserk+=/shred,if=active_bt_triggers=2&buff.bt_shred.down
+actions.berserk+=/shred,if=(active_bt_triggers=2|(talent.dire_fixation.enabled&!debuff.dire_fixation.up))&buff.bt_shred.down
 actions.berserk+=/brutal_slash,if=active_bt_triggers=2&buff.bt_brutal_slash.down
 actions.berserk+=/moonfire_cat,if=active_bt_triggers=2&buff.bt_moonfire.down
 actions.berserk+=/thrash_cat,if=active_bt_triggers=2&buff.bt_thrash.down&!talent.thrashing_claws&variable.need_bt&(refreshable|talent.brutal_slash.enabled)
@@ -86,21 +89,21 @@ actions.bloodtalons+=/moonfire_cat,if=refreshable&buff.bt_moonfire.down&spell_ta
 actions.bloodtalons+=/thrash_cat,target_if=refreshable,if=buff.bt_thrash.down&!talent.thrashing_claws.enabled
 actions.bloodtalons+=/shred,if=buff.bt_shred.down&spell_targets.swipe_cat=1&(!talent.wild_slashes.enabled|(!debuff.dire_fixation.up&talent.dire_fixation.enabled))
 actions.bloodtalons+=/swipe_cat,if=buff.bt_swipe.down&talent.wild_slashes.enabled
-actions.bloodtalons+=/moonfire_cat,target_if=max:ticks_gained_on_refresh,if=buff.bt_moonfire.down&spell_targets.swipe_cat<5
+actions.bloodtalons+=/moonfire_cat,target_if=max:(3*refreshable)+dot.adaptive_swarm_damage.ticking,if=buff.bt_moonfire.down&spell_targets.swipe_cat<5
 actions.bloodtalons+=/swipe_cat,if=buff.bt_swipe.down
-actions.bloodtalons+=/moonfire_cat,target_if=max:ticks_gained_on_refresh,if=buff.bt_moonfire.down
-# If we have BrS and nothing better to cast, check if shred beats thrash DD (or if SA is up)
-actions.bloodtalons+=/shred,target_if=max:target.time_to_die,if=action.shred.damage>action.thrash_cat.damage&buff.bt_shred.down&!buff.sudden_ambush.up&!(variable.lazy_swipe&talent.wild_slashes)
+actions.bloodtalons+=/moonfire_cat,target_if=max:(3*refreshable)+dot.adaptive_swarm_damage.ticking,if=buff.bt_moonfire.down
+# If we have BrS and nothing better to cast, thrash at 5+ targets unless dire fixation is talented.
+actions.bloodtalons+=/shred,target_if=max:target.time_to_die,if=(spell_targets>5|talent.dire_fixation.enabled)&buff.bt_shred.down&!buff.sudden_ambush.up&!(variable.lazy_swipe&talent.wild_slashes)
 actions.bloodtalons+=/thrash_cat,if=buff.bt_thrash.down
-# this line is for the lazy-swipe build only, basically the idea is to only use swipe thrash and rake in aoe. This just finds the best reapplication if you really need 3rd builder for bt
-actions.bloodtalons+=/rake,target_if=min:(25*(persistent_multiplier<dot.rake.pmultiplier)+dot.rake.remains),if=buff.bt_rake.down&variable.lazy_swipe&talent.wild_slashes
+# This just finds the best reapplication if you really need 3rd builder for bt
+actions.bloodtalons+=/rake,target_if=min:(25*(persistent_multiplier<dot.rake.pmultiplier)+dot.rake.remains),if=buff.bt_rake.down&(spell_targets.swipe_cat>4&!talent.dire_fixation|talent.wild_slashes&variable.lazy_swipe)
 
 actions.builder=run_action_list,name=clearcasting,if=buff.clearcasting.react
 actions.builder+=/brutal_slash,if=cooldown.brutal_slash.full_recharge_time<4
 # stop pooling if we can use a clearcasting proc
 actions.builder+=/pool_resource,if=!action.rake.ready&(dot.rake.refreshable|(buff.sudden_ambush.up&persistent_multiplier>dot.rake.pmultiplier&dot.rake.remains>6))&!buff.clearcasting.react
 actions.builder+=/shadowmeld,if=action.rake.ready&!buff.sudden_ambush.up&(dot.rake.refreshable|dot.rake.pmultiplier<1.4)&!buff.prowl.up&!buff.apex_predators_craving.up
-actions.builder+=/rake,if=refreshable|(buff.sudden_ambush.up&persistent_multiplier>dot.rake.pmultiplier&dot.rake.remains>6)
+actions.builder+=/rake,if=refreshable|(buff.sudden_ambush.up&persistent_multiplier>dot.rake.pmultiplier)
 # repeating here is necessary, otherwise moonfire will occassionally be casted instead
 actions.builder+=/run_action_list,name=clearcasting,if=buff.clearcasting.react
 actions.builder+=/moonfire_cat,target_if=refreshable
@@ -118,25 +121,27 @@ actions.cooldown=use_item,name=algethar_puzzle_box,if=fight_remains<35|(!variabl
 actions.cooldown+=/use_item,name=algethar_puzzle_box,if=variable.align_3minutes&(cooldown.bs_inc.remains<3&(!variable.lastZerk|!variable.lastConvoke|(variable.lastConvoke&cooldown.convoke_the_spirits.remains<13)))
 # next two lines check if the current pull is long enough to justify cd usage. If its the last pull, itll always use cds.
 actions.cooldown+=/incarnation,target_if=max:target.time_to_die,if=(target.time_to_die<fight_remains&target.time_to_die>25)|target.time_to_die=fight_remains
+# its a gain to hold your last berserk cast to line it up with convoke (but not vice versa)
 actions.cooldown+=/berserk,target_if=max:target.time_to_die,if=((target.time_to_die<fight_remains&target.time_to_die>18)|target.time_to_die=fight_remains)&((!variable.lastZerk)|(fight_remains<23)|(variable.lastZerk&!variable.lastConvoke)|(variable.lastConvoke&cooldown.convoke_the_spirits.remains<10))
 actions.cooldown+=/berserking,if=!variable.align_3minutes|buff.bs_inc.up
 actions.cooldown+=/use_item,name=mirror_of_fractured_tomorrows|irideus_fragment,if=!variable.align_3minutes|buff.bs_inc.up|(variable.lastConvoke&!variable.lastZerk&cooldown.convoke_the_spirits.remains=0)
-actions.cooldown+=/potion,if=buff.bs_inc.up|fight_remains<32|(fight_remains<cooldown.bs_inc.remains&variable.lastConvoke&cooldown.convoke_the_spirits.remains<10)
-# checks to make sure you can actually fit convoke into the pull.
-actions.cooldown+=/convoke_the_spirits,target_if=max:target.time_to_die,if=((target.time_to_die<fight_remains&target.time_to_die>5)|target.time_to_die=fight_remains)&(fight_remains<5|(dot.rip.remains>5&buff.tigers_fury.up&(combo_points<2|(buff.bs_inc.up&combo_points=2))&(!variable.lastConvoke|!variable.lastZerk|buff.bs_inc.up)))
+actions.cooldown+=/potion,if=buff.bs_inc.up|fight_remains<32|(!variable.lastZerk&variable.lastConvoke&cooldown.convoke_the_spirits.remains<10)
+# checks to make sure you can actually fit convoke into the pull. this portion -> (time+fight_remains+10)%%300<time%%300) is just checking if you'll get another potion use before fight ends. 
+actions.cooldown+=/convoke_the_spirits,target_if=max:target.time_to_die,if=((target.time_to_die<fight_remains&target.time_to_die>5-talent.ashamanes_guidance.enabled)|target.time_to_die=fight_remains)&(fight_remains<5|(dot.rip.remains>5&buff.tigers_fury.up&(combo_points<2|(buff.bs_inc.up&combo_points<=3))))&(!variable.lastConvoke|buff.potion.up|(time+fight_remains+10)%%300>time%%300)&(talent.dire_fixation.enabled&debuff.dire_fixation.up|!talent.dire_fixation.enabled|spell_targets.swipe_cat>1)
 actions.cooldown+=/use_item,name=manic_grieftorch,target_if=max:target.time_to_die,if=energy.deficit>40
 actions.cooldown+=/use_items
+actions.cooldown+=/use_item,name=beacon_to_the_beyond
 
 actions.finisher=primal_wrath,if=((dot.primal_wrath.refreshable&!talent.circle_of_life_and_death.enabled)|dot.primal_wrath.remains<6|(talent.tear_open_wounds.enabled|(spell_targets.swipe_cat>4&!talent.rampant_ferocity.enabled)))&spell_targets.primal_wrath>1&talent.primal_wrath.enabled
-actions.finisher+=/rip,target_if=refreshable
+actions.finisher+=/rip,target_if=refreshable&(!talent.primal_wrath.enabled|spell_targets.swipe_cat=1)
 actions.finisher+=/pool_resource,for_next=1,if=!action.tigers_fury.ready&buff.apex_predators_craving.down
 actions.finisher+=/ferocious_bite,max_energy=1,target_if=max:target.time_to_die,if=buff.apex_predators_craving.down&(!buff.bs_inc.up|(buff.bs_inc.up&!talent.soul_of_the_forest.enabled))
 actions.finisher+=/ferocious_bite,target_if=max:target.time_to_die,if=(buff.bs_inc.up&talent.soul_of_the_forest.enabled)|buff.apex_predators_craving.up
 
-actions.variables=variable,name=need_bt,value=talent.bloodtalons.enabled&buff.bloodtalons.stack<2
+actions.variables=variable,name=need_bt,value=talent.bloodtalons.enabled&buff.bloodtalons.stack<=1
 actions.variables+=/variable,name=align_3minutes,value=spell_targets.swipe_cat=1&!fight_style.dungeonslice
 actions.variables+=/variable,name=lastConvoke,value=fight_remains>cooldown.convoke_the_spirits.remains+3&((talent.ashamanes_guidance.enabled&fight_remains<(cooldown.convoke_the_spirits.remains+60))|(!talent.ashamanes_guidance.enabled&fight_remains<(cooldown.convoke_the_spirits.remains+120)))
 actions.variables+=/variable,name=lastZerk,value=fight_remains>(30+(cooldown.bs_inc.remains%1.6))&((talent.berserk_heart_of_the_lion.enabled&fight_remains<(90+(cooldown.bs_inc.remains%1.6)))|(!talent.berserk_heart_of_the_lion.enabled&fight_remains<(180+cooldown.bs_inc.remains)))
 actions.variables+=/variable,name=zerk_biteweave,op=reset
 actions.variables+=/variable,name=regrowth,op=reset
-actions.variable+=/variable,name=lazy_swipe,op=reset
+actions.variables+=/variable,name=lazy_swipe,op=reset


### PR DESCRIPTION
Add Renewal to apl_variable 'Regrowth'
Convoke now casts at 3 cp or fewer instead of 2cp or fewer during berserk
Holds convoke and feral frenzy if dire fixation isn't applied to the target in single target scenarios 
Add self-cast swarm line for unbridled (to be of use later)
Improve moonfire usage in AoE
Decrease shred priority with some talent builds on larger target counts
Fixed typo in variables