### PR TITLE
fix: Slight CSS Rework for Checkboxes 

### DIFF
--- a/layouts/shortcodes/checkbox.html
+++ b/layouts/shortcodes/checkbox.html
@@ -3,15 +3,17 @@
 {{ $radio := .Get "radio" }}
 {{ $checked := isset .Params "checked" }}
 
-<input type="checkbox" data-id="{{ $id }}-cb" {{ if $checked }}checked{{ end }} {{ if $radio }}data-radio="{{ $radio }}-cb" {{ end }}>
-<label for="{{ $id }}-cb" class="non-selectable">
-    {{ if $spell }}
-        <a class="tooltip spell-tooltip" data-tooltip-href="http://www.wowdb.com/spells/{{ $spell }}"
-            onclick="toggleCheckbox(event, '{{ $id }}-cb');">{{ .Inner | safeHTML }}
-        </a>
-    {{ else }}
-        <a class="tooltip spell-tooltip" onclick="toggleCheckbox(event, '{{ .Get "id" }}-cb');">
-            {{ .Inner | safeHTML }}
-        </a>
-    {{ end }}
-</label>
+<span class="custom-checkbox">
+    <input type="checkbox" id="{{ $id }}-cb" data-id="{{ $id }}-cb" {{ if $checked }}checked{{ end }} {{ if $radio }}data-radio="{{ $radio }}-cb" {{ end }}>
+    <label for="{{ $id }}-cb" class="non-selectable">
+        {{ if $spell }}
+            <a class="tooltip spell-tooltip" data-tooltip-href="http://www.wowdb.com/spells/{{ $spell }}"
+                onclick="toggleCheckbox(event, '{{ $id }}-cb');">{{ .Inner | safeHTML }}
+            </a>
+        {{ else }}
+            <a class="tooltip spell-tooltip" onclick="toggleCheckbox(event, '{{ .Get "id" }}-cb');">
+                {{ .Inner | safeHTML }}
+            </a>
+        {{ end }}
+    </label>
+</span>

--- a/themes/dg-theme/assets/css/article.scss
+++ b/themes/dg-theme/assets/css/article.scss
@@ -220,6 +220,26 @@ a.tooltip {
     -ms-user-select: none;
 }
 
+.custom-checkbox {
+    display: inline-block; /* This makes the element inline, but allows block-level styling */
+    margin-right: 10px; /* Adds some space to the right of each checkbox */
+    vertical-align: middle; /* Aligns the checkbox vertically with adjacent elements */
+}
+
+.custom-checkbox input[type="checkbox"] {
+    margin-right: 5px; /* Space between the checkbox and the label */
+}
+
+.custom-checkbox label {
+    vertical-align: middle; /* Ensures the label aligns with the checkbox */
+    cursor: pointer; /* Changes the cursor to a pointer when hovering over the label */
+}
+
+.custom-checkbox input[type="checkbox"]:checked + label {
+    font-weight: bold; /* Example: makes the label text bold when checked */
+}
+
+
 @media screen and (max-width: 700px) {
   .talent-spell {
     font-size: 1.5rem;


### PR DESCRIPTION
Update Hugo shortcode for inline display and add custom-checkbox CSS

- Modified the Hugo shortcode to wrap checkbox elements in a span with
  the custom-checkbox class for inline rendering.
- Added CSS for custom-checkbox to ensure proper inline display and
  styling of checkboxes and labels.

**Don't approve this yet**
