### PR TITLE
fix: Fixes to the Timeline Warnings

### DIFF
--- a/components/TimelinePlanner/Cast/CastInterval.tsx
+++ b/components/TimelinePlanner/Cast/CastInterval.tsx
@@ -94,7 +94,6 @@ export default function CastInterval({
             if (rectRef && ref.current) {
               rectRef.current = ref.current
             }
-            console.log('hovering', cast)
             changeHover(cast)
           }
         }}

--- a/components/TimelinePlanner/Providers/SettingsProvider.tsx
+++ b/components/TimelinePlanner/Providers/SettingsProvider.tsx
@@ -1,13 +1,10 @@
 import React, { createContext, useContext, useState, useEffect } from 'react'
-import { DruidSpec } from '../TimelineView/TimelineView'
 
 interface SettingsContextType {
   showEventMarkers: boolean
   setShowEventMarkers: (show: boolean) => void
   timestampFormat: 'seconds' | 'minutes'
   setTimestampFormat: (format: 'seconds' | 'minutes') => void
-  currentSpec: DruidSpec
-  setCurrentSpec: (spec: DruidSpec) => void
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined)
@@ -62,7 +59,6 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
   const [showEventMarkers, setShowEventMarkersState] = useState(false)
   const [timestampFormat, setTimestampFormatState] = useState<'seconds' | 'minutes'>('seconds')
   const [isInitialized, setIsInitialized] = useState(false)
-  const [currentSpec, setCurrentSpec] = useState<DruidSpec>('balance')
 
   useEffect(() => {
     const settings = loadSettings()
@@ -92,8 +88,6 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
         setShowEventMarkers,
         timestampFormat,
         setTimestampFormat,
-        currentSpec,
-        setCurrentSpec,
       }}
     >
       {children}

--- a/components/TimelinePlanner/Providers/TimelineLengthProvider.tsx
+++ b/components/TimelinePlanner/Providers/TimelineLengthProvider.tsx
@@ -71,6 +71,7 @@ export function TimelineLengthProvider({
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null)
   const [scrollContainerWidth, setScrollContainerWidth] = useState(0)
 
+  console.log(total_length_s)
   const registerScrollContainer = (element: HTMLDivElement | null) => {
     setScrollContainer(element)
   }

--- a/components/TimelinePlanner/TimelinePlanner.tsx
+++ b/components/TimelinePlanner/TimelinePlanner.tsx
@@ -30,10 +30,6 @@ export default function TimelinePlanner({
   const [currentEncounterId, setCurrentEncounterId] = useState('empty')
   const [tutorialSpells, setTutorialSpells] = useState<PlayerAction[]>([])
 
-  useEffect(() => {
-    console.log(`Selected encounter changed to: ${currentEncounterId}`)
-  }, [currentEncounterId])
-
   const onComplete = (tourName: string | null) => {
     setTutorialSpells([])
   }

--- a/components/TimelinePlanner/Tooltip.tsx
+++ b/components/TimelinePlanner/Tooltip.tsx
@@ -5,6 +5,7 @@ import { useHoverContext } from './Providers/HoverProvider'
 import { useTimelineControls } from './Providers/TimelineLengthProvider'
 import { formatTime } from '../../lib/utils/utilityFunctions'
 import { Cast } from '@/models/Cast'
+import { useSettings } from './Providers/SettingsProvider'
 
 const Tooltip: React.FC = () => {
   const {
@@ -92,9 +93,12 @@ const MouseTooltip = ({ time }: { time: string }) => {
 }
 
 const CastTooltip = ({ cast, width }: { cast: Cast; width: number }) => {
+  const { timestampFormat } = useSettings()
   //round to 1 decimal place
   const startTime = Math.max(0, Math.round(cast.start_s * 10) / 10)
   const endTime = Math.max(0, Math.round(cast.end_s * 10) / 10)
+  const startTimeFormatted = timestampFormat === 'seconds' ? startTime : formatTime(startTime)
+  const endTimeFormatted = timestampFormat === 'seconds' ? endTime : formatTime(endTime)
   return (
     <div
       className="box-border px-2 py-1 text-xs"
@@ -104,9 +108,9 @@ const CastTooltip = ({ cast, width }: { cast: Cast; width: number }) => {
       }}
     >
       <div className="flex flex-row">
-        <div className="w-12">{startTime}s</div>
+        <div className="w-12">{startTimeFormatted}s</div>
         <div className="mt-[7px] h-[3px] flex-1 bg-neutral-400/20" />
-        <div className="w-12 text-right">{endTime}s</div>
+        <div className="w-12 text-right">{endTimeFormatted}s</div>
       </div>
     </div>
   )

--- a/components/TimelinePlanner/Warnings.tsx
+++ b/components/TimelinePlanner/Warnings.tsx
@@ -4,10 +4,9 @@ import { useTimeline } from './Providers/TimelineLengthProvider'
 import { useTimelineContext } from './TimelineProvider/useTimelineContext'
 
 export default function Warnings() {
-  const { currentSpec } = useTimelineContext()
+  const { currentSpec, processedState } = useTimelineContext()
   const { total_length_s } = useTimeline()
   const [isOpen, setIsOpen] = useState(false)
-  const { processedState } = useTimelineContext()
   const timeline = processedState.spells
 
   // Get all warnings from registered warning functions that apply to current spec

--- a/components/TimelinePlanner/Warnings.tsx
+++ b/components/TimelinePlanner/Warnings.tsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react'
 import { registerWarnings } from '@/lib/warnings/registerWarnings'
 import { useTimeline } from './Providers/TimelineLengthProvider'
-import { useSettings } from './Providers/SettingsProvider'
 import { useTimelineContext } from './TimelineProvider/useTimelineContext'
 
 export default function Warnings() {
-  const { currentSpec } = useSettings()
+  const { currentSpec } = useTimelineContext()
   const { total_length_s } = useTimeline()
   const [isOpen, setIsOpen] = useState(false)
   const { processedState } = useTimelineContext()

--- a/lib/utils/utilityFunctions.ts
+++ b/lib/utils/utilityFunctions.ts
@@ -6,8 +6,7 @@ export function formatTime(seconds: number): string {
 
   const mins = Math.floor(seconds / 60)
   const secs = Math.floor(seconds % 60)
-  const ms = Math.floor((seconds % 1) * 100)
-  return `${mins}:${secs.toString().padStart(2, '0')}.${ms.toString().padStart(2, '0')}`
+  return `${mins}:${secs.toString().padStart(2, '0')}`
 }
 
 export function isValid(timelineState: TimelineState, castId: string): boolean {

--- a/lib/warnings/balanceCDEfficiency.ts
+++ b/lib/warnings/balanceCDEfficiency.ts
@@ -1,5 +1,5 @@
-import { SpellToRender, Warning } from '../../types'
-import { Cast } from '../../models/Cast'
+import { SpellToRender, Warning } from '@/types/index'
+import { Cast } from '@/models/Cast'
 
 // Spell IDs for Balance Druid cooldowns
 const CONVOKE_THE_SPIRITS_ID = 391528
@@ -15,10 +15,7 @@ const FORCE_OF_NATURE_ID = 205636
  * @param total_timeline_length_s The total length of the timeline in seconds
  * @returns Array of warning objects with spell names and warning messages
  */
-export function findBalanceCDEfficiency(
-  timeline: SpellToRender[],
-  total_timeline_length_s: number
-): Warning[] {
+export function findBalanceCDEfficiency(timeline: SpellToRender[]): Warning[] {
   const balanceCDEfficiencyWarnings: Warning[] = []
 
   // Find the spell timelines for each cooldown

--- a/lib/warnings/missedCasts.ts
+++ b/lib/warnings/missedCasts.ts
@@ -42,7 +42,7 @@ export function findMissedCastOpportunities(
 
     // Calculate gaps between consecutive casts
     for (let i = 1; i < sortedCasts.length; i++) {
-      const previousCastEnd = sortedCasts[i - 1].start_s + sortedCasts[i - 1].spell.effect_duration
+      const previousCastEnd = sortedCasts[i - 1].end_s
       const currentCastStart = sortedCasts[i].start_s
 
       // Calculate the gap between casts
@@ -50,10 +50,7 @@ export function findMissedCastOpportunities(
       totalGapTime += gap
     }
 
-    // Also check for time after the last cast
-    const lastCastEnd =
-      sortedCasts[sortedCasts.length - 1].start_s +
-      sortedCasts[sortedCasts.length - 1].spell.effect_duration
+    const lastCastEnd = sortedCasts[sortedCasts.length - 1].end_s
     const timeAfterLastCast = total_timeline_length_s - lastCastEnd
     if (timeAfterLastCast > spell.cooldown) {
       totalGapTime += timeAfterLastCast

--- a/lib/warnings/missedCasts.ts
+++ b/lib/warnings/missedCasts.ts
@@ -1,4 +1,4 @@
-import { SpellToRender, Warning } from '../../types'
+import { SpellToRender, Warning } from '@/types/index'
 /**
  * Analyzes a timeline and identifies spells that have gaps between casts
  * where the sum of gaps exceeds the spell's cooldown (indicating missed cast opportunities).

--- a/lib/warnings/registerWarnings.ts
+++ b/lib/warnings/registerWarnings.ts
@@ -5,7 +5,7 @@ export const registerWarnings = [
   {
     name: 'missedCasts',
     warning: findMissedCastOpportunities,
-    spec: ['balance'],
+    spec: ['balance', 'feral', 'guardian', 'resto'],
   },
   {
     name: 'balanceCDEfficiency',

--- a/models/Cast.ts
+++ b/models/Cast.ts
@@ -24,7 +24,6 @@ export class Cast {
   interrupting_cast: Cast | null
 
   interrupt(interrupting_cast: Cast) {
-    console.log('interrupting cast', interrupting_cast)
     this.interrupting_cast = interrupting_cast
     this._chann_end_s = interrupting_cast.start_s
     this._ef_end_s = interrupting_cast.start_s


### PR DESCRIPTION
fixes:
- [DG-61 Changing the time to mm/ss doesnt change the format in the tooltip](https://linear.app/dreamgrove/issue/DG-61/changing-the-time-to-mmss-doesnt-change-the-format-in-the-tooltip)
- [DG-54 Cooldown Efficiency Warning is displayed multiple times for many casts](https://linear.app/dreamgrove/issue/DG-54/cooldown-efficiency-warning-is-displayed-multiple-times-for-many-casts)
- [DG-62 Warnings are displayed for the incorrect spec](https://linear.app/dreamgrove/issue/DG-62/warnings-are-displayed-for-the-incorrect-spec)